### PR TITLE
[FIX] Fix for inconsistent bucketId

### DIFF
--- a/index.js
+++ b/index.js
@@ -782,7 +782,7 @@ app.use(function (req, res, next) {
         function (indexOfBucketWithMinimumUsers, waterfallCallback) {
             const bucketId = indexOfBucketWithMinimumUsers + 1;
             const trafficDetails = TRAFFIC_CONFIG[hostName];
-	    res.locals["bucketId"] = bucketId;
+	    res.locals["bucketId"] = indexOfBucketWithMinimumUsers;
             if (trafficDetails.GROWTH_PERCENTAGE && trafficDetails.GROWTH_PERCENTAGE >= bucketId) {
                 waterfallCallback(null, 'REDIRECT_TO_GROWTH');
             } else {


### PR DESCRIPTION
This is for the fix of inconsistent bucket ID. In one case the bucket ID being sent to ecs-web was the original one and for new users, it was coming index + 1.